### PR TITLE
Fix typo in @public snippet

### DIFF
--- a/snippets/processing-mode/@public
+++ b/snippets/processing-mode/@public
@@ -2,4 +2,4 @@
 # name: @public
 # key: @
 # --
-@private$0
+@public$0


### PR DESCRIPTION
The @public snippet was expanding to "@private" instead of "@public"
