### PR TITLE
Fix flycheck-package warnings in flycheck-processing.el

### DIFF
--- a/flycheck-processing.el
+++ b/flycheck-processing.el
@@ -1,4 +1,4 @@
-;;; flycheck-processing.el --- Flycheck checker for processing-mode  -*- lexical-binding: t; -*-
+;;; flycheck-processing.el --- Flycheck checker for processing-mode
 
 ;; Copyright (C) 2015  Peter Vasil
 


### PR DESCRIPTION
Lexical binding requires Emacs 24 or higher. As the code didn't use lexical binding I removed that from the file header.