### PR TITLE
Camel case support for processing-find-in-reference

### DIFF
--- a/processing-mode.el
+++ b/processing-mode.el
@@ -299,7 +299,7 @@ When calle interactively, prompt the user for QUERY."
 (defun processing-find-in-reference ()
   "Find word under cursor in Processing reference."
   (interactive)
-  (processing--open-query-in-reference (thing-at-point 'word)))
+  (processing--open-query-in-reference (thing-at-point 'symbol)))
 
 (defun processing-open-reference ()
   "Open Processing reference."


### PR DESCRIPTION
I was unable to run 'find in reference' (C-c C-p d) for "loadImage". 
I have included a fix for supporting camel case.